### PR TITLE
created a dialog for BOOST JWT token

### DIFF
--- a/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/dialog/BOOSTJWTDialog.java
+++ b/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/dialog/BOOSTJWTDialog.java
@@ -1,0 +1,82 @@
+package edu.utah.ece.async.sboldesigner.sbol.editor.dialog;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+
+import edu.utah.ece.async.sboldesigner.swing.FormBuilder;
+
+public class BOOSTJWTDialog extends JDialog implements ActionListener{
+	
+	private Component parent;
+	
+	private final JTextField token = new JTextField("");
+	private final JButton submitButton = new JButton("Submit");
+	private final JButton cancelButton = new JButton("Cancel");
+	
+	public BOOSTJWTDialog(Component parent) {
+		super(JOptionPane.getFrameForComponent(parent), "Authentication by BOOST JWT Token", true);
+		this.parent = parent;
+		
+		cancelButton.registerKeyboardAction(this, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+				JComponent.WHEN_IN_FOCUSED_WINDOW);
+		
+		submitButton.addActionListener(this);
+		cancelButton.addActionListener(this);
+		getRootPane().setDefaultButton(submitButton);
+		
+		JPanel buttonPane = new JPanel();
+		buttonPane.setLayout(new BoxLayout(buttonPane, BoxLayout.LINE_AXIS));
+		buttonPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+		buttonPane.add(Box.createHorizontalStrut(100));
+		buttonPane.add(Box.createHorizontalGlue());
+		buttonPane.add(cancelButton);
+		buttonPane.add(submitButton);
+	
+		FormBuilder builder = new FormBuilder();
+		builder.add("JWT Token: ", token);
+		
+		JPanel mainPanel = builder.build();
+		mainPanel.setAlignmentX(LEFT_ALIGNMENT);
+		
+		JLabel infoLabel = new JLabel(
+				"Please provide your BOOST JWT token in order to authenticate your account");
+		
+		Container contentPane = getContentPane();
+		contentPane.add(infoLabel, BorderLayout.PAGE_START);
+		contentPane.add(mainPanel, BorderLayout.CENTER);
+		contentPane.add(buttonPane, BorderLayout.PAGE_END);
+		((JComponent) contentPane).setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+		pack();
+		setLocationRelativeTo(parent);
+		setVisible(true);
+	}
+
+	
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		if (e.getSource() == cancelButton) {
+			setVisible(false);
+			return;
+		}else if(e.getSource() == submitButton) {
+			String mJWT = token.getText();
+			//TODO: Pass this token for BOOST API Call
+		}	
+	}
+}


### PR DESCRIPTION
For authenticating a BOOST account, the user can provide his/her JWT token (it's a alternative to provide username and password)