### PR TITLE
Incorrect name for non-coding RNA

### DIFF
--- a/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/Part.java
+++ b/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/Part.java
@@ -124,6 +124,11 @@ public class Part {
 					.toBufferedImage(Images.scaleImageToWidth(Images.getPartImage("variant-overlay.png"), IMG_WIDTH));
 			image = Images.overlay(image, scaledVariantOverlay, IMG_WIDTH, IMG_HEIGHT);
 		} else {
+			if (!hasSequence) {
+				BufferedImage scaledWarningOverlay = Images.toBufferedImage(
+						Images.scaleImageToWidth(Images.getPartImage("error-advice-sign-overlay.png"), IMG_WIDTH));
+				image = Images.overlay(image, scaledWarningOverlay, IMG_WIDTH, IMG_HEIGHT);
+			}
 		}
 
 		return image;

--- a/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/Parts.java
+++ b/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/Parts.java
@@ -54,7 +54,7 @@ public class Parts {
 			ImageType.SHORT_OVER_BASELINE, SequenceOntology.TERMINATOR);
 	public static final Part CIRCULAR = createPart("Circular Backbone", "Cir", "blank-backbone.png",
 			ImageType.CENTERED_ON_BASELINE, "SO:0000755");
-	public static final Part NON_CODING_RNA_GENE = createPart("Non-Coding RNA Gene", "gRNA", "non-coding-rna-gene.png",
+	public static final Part NON_CODING_RNA_GENE = createPart("Non-Coding RNA Gene", "ncRNA", "non-coding-rna-gene.png",
 			ImageType.SHORT_OVER_BASELINE, "SO:0001263");
 	public static final Part ORI = createPart("Origin of Replication", "Ori", "origin-of-replication.png",
 			ImageType.CENTERED_ON_BASELINE, SequenceOntology.ORIGIN_OF_REPLICATION);

--- a/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/Parts.java
+++ b/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/Parts.java
@@ -54,7 +54,7 @@ public class Parts {
 			ImageType.SHORT_OVER_BASELINE, SequenceOntology.TERMINATOR);
 	public static final Part CIRCULAR = createPart("Circular Backbone", "Cir", "blank-backbone.png",
 			ImageType.CENTERED_ON_BASELINE, "SO:0000755");
-	public static final Part NON_CODING_RNA_GENE = createPart("Non-Coding RNA Gene", "ncRNA", "non-coding-rna-gene.png",
+	public static final Part NON_CODING_RNA_GENE = createPart("Non-Coding RNA Gene", "gRNA", "non-coding-rna-gene.png",
 			ImageType.SHORT_OVER_BASELINE, "SO:0001263");
 	public static final Part ORI = createPart("Origin of Replication", "Ori", "origin-of-replication.png",
 			ImageType.CENTERED_ON_BASELINE, SequenceOntology.ORIGIN_OF_REPLICATION);


### PR DESCRIPTION
The "gRNA" abbreviation has been corrected to "ncRNA".