### PR TITLE
Have added functionality to rebuild SequenceAnnotations

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -26,6 +26,7 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/src/main/java/edu/utah/ece/async/sboldesigner/sbol/ProvenanceUtil.java
+++ b/src/main/java/edu/utah/ece/async/sboldesigner/sbol/ProvenanceUtil.java
@@ -138,6 +138,8 @@ public class ProvenanceUtil {
 			designerAgent.setDescription(
 					"SBOLDesigner is a simple, biologist-friendly CAD software tool for creating and manipulating the sequences of genetic constructs using the Synthetic Biology Open Language (SBOL) 2 data model. Throughout the design process, SBOL Visual symbols, a system of schematic glyphs, provide standardized visualizations of individual parts. SBOLDesigner completes a workflow for users of genetic design automation tools. It combines a simple user interface with the power of the SBOL standard and serves as a launchpad for more detailed designs involving simulations and experiments. Some new features in SBOLDesigner are SynBioHub integration, local repositories, importing of parts/sequences from existing files, import and export of GenBank and FASTA files, extended role ontology support, the ability to partially open designs with multiple root ComponentDefinitions, backward compatibility with SBOL 1.1, and versioning.");
 			designerAgent.createAnnotation(new QName("http://purl.org/dc/elements/1.1/", "creator", "dc"),
+					"Samuel Bridge");
+			designerAgent.createAnnotation(new QName("http://purl.org/dc/elements/1.1/", "creator", "dc"),
 					"Michael Zhang");
 			designerAgent.createAnnotation(new QName("http://purl.org/dc/elements/1.1/", "creator", "dc"),
 					"Chris Myers");

--- a/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/SBOLDesign.java
+++ b/src/main/java/edu/utah/ece/async/sboldesigner/sbol/editor/SBOLDesign.java
@@ -1792,13 +1792,57 @@ public class SBOLDesign {
 		}
 
 		doc = CombinatorialExpansionUtil.createCombinatorialDesign(doc);
-
+		
+		
+		for(ComponentDefinition c : doc.getRootComponentDefinitions()) {
+			rebuildSequences(c);
+		}
+		
 		if (doc != null) {
 			if (!file.getName().contains(".")) {
 				file = new File(file + ".xml");
 			}
 			SBOLWriter.write(doc, new FileOutputStream(file));
 		}
+	}
+	
+	private void rebuildSequences(ComponentDefinition comp) throws SBOLValidationException {
+		Set<SequenceAnnotation> oldSequenceAnn = comp.getSequenceAnnotations();
+		comp.clearSequenceAnnotations();
+		Set<Sequence> currSequences = new HashSet<Sequence>();
+		int start = 1;
+		int length;
+		int count = 0;
+		String newSeq = "";
+		ComponentDefinition curr;
+		for(org.sbolstandard.core2.Component c : comp.getSortedComponents()) {
+			curr = c.getDefinition();
+			
+			length = 0;
+			//Append sequences to build newly constructed sequence
+			for(Sequence s : curr.getSequences()) {
+				currSequences.add(s);
+				newSeq.concat(s.getElements());
+				length += s.getElements().length();
+			}
+			
+			OrientationType o = OrientationType.INLINE;
+			for(SequenceAnnotation sa : oldSequenceAnn) {
+				if(sa.getComponent().getIdentity() == c.getIdentity()) {
+					o = sa.getLocations().iterator().next().getOrientation();
+				}
+			}
+			
+			SequenceAnnotation seqAnn = comp.createSequenceAnnotation("SequenceAnnotation_"+count, "Range" , start, start+length, o);
+			
+			seqAnn.setComponent(c.getIdentity());
+			
+			start += length+1;
+			count++;
+		}
+		
+		comp.getSequences().iterator().next().setElements(newSeq);
+		
 	}
 
 	public static void uploadDesign(Component panel, SBOLDocument uploadDoc, File uploadFile)

--- a/src/main/java/edu/utah/ece/async/sboldesigner/versioning/Terms.java
+++ b/src/main/java/edu/utah/ece/async/sboldesigner/versioning/Terms.java
@@ -18,8 +18,6 @@ package edu.utah.ece.async.sboldesigner.versioning;
 import java.util.Calendar;
 import java.util.UUID;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.openrdf.model.Literal;
 import org.openrdf.model.Resource;
 import org.openrdf.model.Statement;
@@ -85,9 +83,9 @@ public class Terms {
 		return VF.createLiteral(label);		
 	}
 	
-	public static Literal literal(Calendar date) {
-		return VF.createLiteral(DatatypeConverter.printDateTime(date), XMLSchema.DATETIME);		
-	}
+//	public static Literal literal(Calendar date) {
+//		return VF.createLiteral(DatatypeConverter.printDateTime(date), XMLSchema.DATETIME);		
+//	}
 
 	public static Statement stmt(Resource s, URI p, Value o) {
 		return VF.createStatement(s, p, o);


### PR DESCRIPTION
Have added functionality to rebuild SequenceAnnotations whilst also maintaining orientation. Additionally, the SequenceConstraints are preserved and properly adjusted when elements are removed. 

Appears to generate the SBOL you would expect upon expanding and saving a combinatoral design.